### PR TITLE
Updates media URL for new Hygraph asset management

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,8 +25,8 @@ const config = withPlugins(
       remotePatterns: [
         {
           protocol: "https",
-          hostname: "media.graphassets.com",
-        },
+          hostname: "**.graphassets.com",
+        }
       ],
     },
     webpack: (config) => {


### PR DESCRIPTION
Upcoming changes to the asset management system use a regional server for asset URIs so we need it to be a wildcard for the subdomain.